### PR TITLE
don't match on xs in LookupVec1

### DIFF
--- a/agda.lagda.tex
+++ b/agda.lagda.tex
@@ -1132,7 +1132,7 @@ module LookupVec1 where
 \end{code}
 \begin{code}[number]
   lookupVec : {A : Set} {n : Nat} → Vec A n → Fin n → A
-  lookupVec (x :: xs) i = {!!}
+  lookupVec xs i = {!!}
 \end{code}
 Notice that the length $n$ of the vector is also used as the upper
 bound for the position: this way we enforce that the position really is in


### PR DESCRIPTION
I enjoyed these notes tremendously, thank you so much for making them and sharing them!

---

I found a very minor typo in the `lookupVec` example. In equation 25, the reader doesn't yet expect to see the `x :: xs` split. The split should happen for the first time in equation 26.